### PR TITLE
引数付きで sd してしまったとき

### DIFF
--- a/etc/sd_cl
+++ b/etc/sd_cl
@@ -68,10 +68,10 @@ _sd_cl () { # {{{
     if [ $# -eq 0 ];then
       # Current directory
       curdir=$(pwd -P)
-    fi
 
-    _sf_main -p "$curdir" >/dev/null
-    return $?
+      _sf_main -p "$curdir" >/dev/null
+      return $?
+    fi
   elif [ "$sdcl" != "cl" ];then
     echo "Usage: _sd_cl <sd or cl> [arg1 [arg2 [...]]]"
     return 1


### PR DESCRIPTION
引数付きで sd してしまったときの動作を修正してみました。

たとえば、`sd -hogege`などとしまったときに、誤って `-hogege`がリストに登録されてしまいます。これをアドホックに直してみました。

そのかわり、

```
bash: cd: -h: invalid option
cd: usage: cd [-L|-P] [dir]
```

などと表示されるようになりますが、まあこれはいいかなと^^;
